### PR TITLE
Update help-menu

### DIFF
--- a/menu-includes/help-menu
+++ b/menu-includes/help-menu
@@ -30,7 +30,7 @@ Bunsen Help Files,^checkout(BLhelp)
 ^tag(DebianWWW)
 Back,^back()
 Debian Documentation,x-www-browser "https://www.debian.org/doc/"
-Debian Handbook,x-www-browser "https://debian-handbook.info/browse/buster/"
+Debian Handbook,x-www-browser "https://debian-handbook.info/browse/bullseye/"
 Debian Reference,x-www-browser "https://www.debian.org/doc/manuals/debian-reference/"
 Wiki,x-www-browser "https://wiki.debian.org/"
 FAQsFromDebianUser,x-www-browser "https://wiki.debian.org/FAQsFromDebianUser"


### PR DESCRIPTION
Beryllium shall be based on stable debian: bullseye. Link to the handbook must be updated accoringly